### PR TITLE
Don't run precommit hooks for auditmated commits

### DIFF
--- a/bin/audit.sh
+++ b/bin/audit.sh
@@ -9,7 +9,7 @@ fi
 
 npm audit fix
 git add package.json package-lock.json
-git commit -m "$MESSAGE"
+git commit --no-verify -m "$MESSAGE"
 
 # if audit fix didn't change anything the commit will exit with non-0 exit code
 # catch that error code and exit successfully


### PR DESCRIPTION
The precommit hooks before the push should handle what's necessary, running again is redundant.
In our use case Husky won't touch `package.json` and `package-lock.json` anyway.