### PR TITLE
Added Husky v1 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,34 @@ Automated npm auditing
 # Usage
 
 The `auditmated` binary will run `npm audit fix` in the current repo. If `package.json` and `package-lock.json` have been updated `auditmated` will commit those changes
-with a commit message of `<branch-name> npm audit fix`. This will fix any problems identified by `npm audit` that can be fixed by patch or minor version bumps. 
+with a commit message of `<branch-name> npm audit fix`. This will fix any problems identified by `npm audit` that can be fixed by patch or minor version bumps.
 
 `auditmated` only supports bash.
 
 # Example with Husky
+
 This will run auditing as a pre-push hook using [husky](https://www.npmjs.com/package/husky):
+
+```json
+{
+  "name": "audit-test",
+  "version": "1.0.0",
+  "main": "index.js",
+  "husky": {
+    "hooks": {
+      "pre-push": "auditmated"
+    }
+  },
+  "devDependencies": {
+    "auditmated": "0.1.0",
+    "husky": "^1.0.0"
+  }
+}
 ```
+
+If you are using Husky v0, define as a `prepush` script.
+
+```json
 {
   "name": "audit-test",
   "version": "1.0.0",
@@ -18,10 +39,10 @@ This will run auditing as a pre-push hook using [husky](https://www.npmjs.com/pa
   "scripts": {
     "prepush": "auditmated"
   },
-    "devDependencies": {
+  "devDependencies": {
     "auditmated": "0.1.0",
     "husky": "^0.14.3"
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
> Warning: Setting pre-push script in package.json > scripts will be deprecated
> Please move it to husky.hooks in package.json, a .huskyrc file, or a husky.config.js file
> Or run ./node_modules/.bin/husky-upgrade for automatic update
> 
> See https://github.com/typicode/husky for usage
