### PR TITLE
Changed hook to use pre-commit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ with a commit message of `<branch-name> npm audit fix`. This will fix any proble
 
 # Example with Husky
 
-This will run auditing as a pre-push hook using [husky](https://www.npmjs.com/package/husky):
+This will run auditing as a pre-commit hook using [husky](https://www.npmjs.com/package/husky):
 
 ```json
 {
@@ -19,7 +19,7 @@ This will run auditing as a pre-push hook using [husky](https://www.npmjs.com/pa
   "main": "index.js",
   "husky": {
     "hooks": {
-      "pre-push": "auditmated"
+      "pre-commit": "auditmated"
     }
   },
   "devDependencies": {
@@ -29,7 +29,7 @@ This will run auditing as a pre-push hook using [husky](https://www.npmjs.com/pa
 }
 ```
 
-If you are using Husky v0, define as a `prepush` script.
+If you are using Husky v0.14, define as a `precommit` script.
 
 ```json
 {
@@ -37,7 +37,7 @@ If you are using Husky v0, define as a `prepush` script.
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "prepush": "auditmated"
+    "precommit": "auditmated"
   },
   "devDependencies": {
     "auditmated": "0.1.0",

--- a/bin/audit.sh
+++ b/bin/audit.sh
@@ -8,7 +8,7 @@ if [[ $BRANCH = 'master' ]] || [[ $BRANCH = 'develop' ]]; then
   exit 0
 fi
 
-if [[ "$(npm audit fix)" ]]; then
+if [[ ! "$(npm audit fix)" ]]; then
   # if audit fix didn't change anything the commit will exit with non-0 exit code
   # catch that error code and exit successfully
   echo 'audit: minor and patch version of deps have no known security issues'
@@ -16,4 +16,4 @@ if [[ "$(npm audit fix)" ]]; then
 fi
 
 git add package.json package-lock.json &&
-git commit --no-verify -m "$MESSAGE"
+  git commit --no-verify -m "$MESSAGE"

--- a/bin/audit.sh
+++ b/bin/audit.sh
@@ -1,18 +1,19 @@
-#!/bin/bash
-BRANCH=`git rev-parse --abbrev-ref HEAD`
+#!/bin/env bash
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 MESSAGE="$BRANCH npm audit fix"
 
-if [[ $BRANCH = 'master' ]] || [[ $BRANCH = 'develop' ]] ; then
-  echo 'skipping audit on '$BRANCH' branch'
+if [[ $BRANCH = 'master' ]] || [[ $BRANCH = 'develop' ]]; then
+  echo 'skipping audit on '"$BRANCH"' branch'
   exit 0
 fi
 
-npm audit fix
-git add package.json package-lock.json
-git commit --no-verify -m "$MESSAGE"
-
-# if audit fix didn't change anything the commit will exit with non-0 exit code
-# catch that error code and exit successfully
-if [[ $? -ne 0 ]] ; then
+if [[ "$(npm audit fix)" ]]; then
+  # if audit fix didn't change anything the commit will exit with non-0 exit code
+  # catch that error code and exit successfully
   echo 'audit: minor and patch version of deps have no known security issues'
+  exit 0
 fi
+
+git add package.json package-lock.json &&
+git commit --no-verify -m "$MESSAGE"


### PR DESCRIPTION
`pre-push` cannot guarantee a new commit is added before the push, but calling `npm audit fix`on pre-commit will. This means `npm audit` could be invoked slightly more times than necessary, but will actually work as intended.

Updated some syntax to be more safe and up-to-date.